### PR TITLE
Revert to original event name for codeview.toggled

### DIFF
--- a/src/js/base/module/Codeview.js
+++ b/src/js/base/module/Codeview.js
@@ -61,7 +61,7 @@ export default class CodeView {
     } else {
       this.activate();
     }
-    this.context.triggerEvent('note-codeview.note-toggled');
+    this.context.triggerEvent('codeview.toggled');
   }
 
   /**


### PR DESCRIPTION
Event was triggered with name "note-codeview.note-toggled" instead of
"codeview.toggled" which breaks user code relying on that event.

